### PR TITLE
fix: keep frontend default api base on 4100

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.pnpm-store
+apps/api/dist
+apps/api/node_modules
+apps/web/node_modules
+apps/api/.env
+apps/api/data/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+# Logic App Blob UI
+
+This project is a small full-stack prototype for orchestrating Azure Logic App runs against files stored in Azure Blob Storage.
+It provides:
+
+- File upload to Blob storage
+- Logic App trigger with parameter selection
+- Run tracking stored in a lightweight JSON file database
+- Output file browsing, preview, and download
+
+## Project structure
+
+```
+/apps
+  /api        # Node.js + Express + TypeScript backend
+  /web        # Static HTML/CSS/JS frontend
+```
+
+## Prerequisites
+
+- Node.js 18+
+- pnpm 8+
+- Azure Storage account and container
+- Logic App manual trigger endpoint (or mock)
+
+## Setup
+
+1. Install dependencies (run in the repo root after cloning):
+
+   ```bash
+   pnpm install
+   ```
+
+2. Copy the API environment file and update it with your Azure details:
+
+   ```bash
+   cp apps/api/.env.sample apps/api/.env
+   ```
+
+3. Create the data folder that will hold the JSON store for run history (the app will create the file automatically on first run):
+
+   ```bash
+   mkdir -p apps/api/data
+   ```
+
+4. Start the backend API (development mode watches for changes):
+
+   ```bash
+   pnpm dev
+   ```
+
+   The API listens on http://localhost:4100 by default.
+
+5. In a new terminal, serve the static frontend from `apps/web`. You can use any static file server; the following command uses
+pnpm to download a temporary one:
+
+   ```bash
+   pnpm dlx serve apps/web --listen 5173 --single
+   ```
+
+   Then open http://localhost:5173 in your browser. Unless you explicitly override it, the frontend talks to `http://localhost:4100/api`. If you serve the pages from the same origin as the API (for example, hosting everything from port 4100 or a production domain), the scripts automatically reuse that origin. To point at a different backend, set `window.API_BASE_URL = "https://your-host/api";` in a small script tag before loading any page JavaScript.
+
+## Pushing to GitHub
+
+If you would like to publish this repository to your own GitHub account, you can create a new remote and push the existing history:
+
+```bash
+git remote add origin git@github.com:<your-account>/<your-repo>.git
+git push -u origin work
+```
+
+Replace `<your-account>` and `<your-repo>` with the values for your GitHub project. If the remote already exists (for example, after cloning from GitHub), you only need the final `git push` command.
+
+## Notes
+
+- The backend persists run metadata to a JSON file for easy local development; the path is configurable via `RUNS_DB_PATH`.
+- This is a prototype; authentication and production hardening are intentionally left out but the structure allows future integration with Microsoft Entra ID.
+- All storage account secrets remain on the server; the frontend communicates solely via the `/api` routes.

--- a/apps/api/.env.sample
+++ b/apps/api/.env.sample
@@ -1,0 +1,11 @@
+PORT=4100
+AZURE_STORAGE_ACCOUNT_NAME=youraccount
+AZURE_STORAGE_ACCOUNT_KEY=yourkey
+AZURE_STORAGE_CONTAINER=input-output
+INPUT_PREFIX=input/
+OUTPUT_PREFIX=output/
+LOGIC_APP_TRIGGER_URL=https://<region>.logic.azure.com/workflows/<id>/triggers/manual/paths/invoke?...&sig=<sig>
+BLOB_SAS_EXPIRY_MINUTES=30
+RUNS_DB_PATH=./data/runs.json
+# Optional bearer if Logic App requires it (if not using SAS trigger):
+# LOGIC_APP_BEARER=eyJ...

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@app/api",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@azure/storage-blob": "^12.16.0",
+    "axios": "^1.6.8",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2",
+    "multer": "^1.4.5-lts.1",
+    "ulid": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/multer": "^1.4.11",
+    "@types/node": "^20.11.30",
+    "tsx": "^4.7.1",
+    "typescript": "^5.4.2"
+  }
+}

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,0 +1,3 @@
+import dotenv from "dotenv";
+
+dotenv.config();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,50 @@
+import cors from "cors";
+import express from "express";
+import "./env.js";
+import { createLogicAppRouter } from "./routes/logicapp.js";
+import filesRouter from "./routes/files.js";
+import { createRunsRouter } from "./routes/runs.js";
+import { createOutputRouter } from "./routes/output.js";
+import { RunsRepository } from "./services/db.js";
+
+const port = parseInt(process.env.PORT ?? "4100", 10);
+const allowedOrigins = [
+  "http://localhost:4100",
+  "http://localhost:5173",
+  process.env.WEB_ORIGIN,
+].filter(Boolean) as string[];
+
+const app = express();
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin) || allowedOrigins.includes("*")) {
+        return callback(null, origin ?? true);
+      }
+      return callback(null, false);
+    },
+    credentials: false,
+  })
+);
+app.use(express.json({ limit: "5mb" }));
+
+const runsStorePath = process.env.RUNS_DB_PATH ?? "./data/runs.json";
+const runsRepo = new RunsRepository(runsStorePath);
+
+app.get("/api/health", (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.use("/api/files", filesRouter);
+app.use("/api/logicapp", createLogicAppRouter(runsRepo));
+app.use("/api/runs", createRunsRouter(runsRepo));
+app.use("/api/output", createOutputRouter());
+
+app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  console.error("Unhandled error", err);
+  res.status(500).json({ ok: false, message: "Internal server error" });
+});
+
+app.listen(port, () => {
+  console.log(`API server listening on port ${port}`);
+});

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -1,0 +1,64 @@
+import "../env.js";
+import { Router } from "express";
+import multer from "multer";
+import path from "path";
+import {
+  getBlobSasUrl,
+  guessContentType,
+  listBlobs,
+  uploadBlob,
+} from "../services/blob.js";
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+const inputPrefix = process.env.INPUT_PREFIX ?? "input/";
+const sasExpiry = parseInt(process.env.BLOB_SAS_EXPIRY_MINUTES ?? "30", 10);
+const MAX_FILE_SIZE = 200 * 1024 * 1024; // 200 MB
+
+router.post("/upload", upload.single("file"), async (req, res) => {
+  try {
+    const file = req.file;
+    if (!file) {
+      return res.status(400).json({ ok: false, message: "File is required" });
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return res.status(413).json({
+        ok: false,
+        message: "File too large. Maximum size is 200 MB.",
+      });
+    }
+
+    const original = path.basename(file.originalname).replace(/[^a-zA-Z0-9_.-]/g, "_");
+    const blobName = `${inputPrefix}${Date.now()}__${original}`;
+    const contentType = file.mimetype || guessContentType(original);
+
+    await uploadBlob(file.buffer, contentType, blobName);
+
+    const sasUrl = getBlobSasUrl(blobName, "r", sasExpiry);
+
+    return res.json({
+      ok: true,
+      fileName: blobName,
+      sasUrl,
+      contentType,
+    });
+  } catch (error) {
+    console.error("Upload failed", error);
+    return res.status(500).json({ ok: false, message: "Upload failed" });
+  }
+});
+
+router.get("/list", async (req, res) => {
+  try {
+    const prefix = (req.query.prefix as string) ?? inputPrefix;
+    const blobs = await listBlobs(prefix);
+    return res.json(blobs);
+  } catch (error) {
+    console.error("List blobs failed", error);
+    return res.status(500).json({ ok: false, message: "Failed to list blobs" });
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/logicapp.ts
+++ b/apps/api/src/routes/logicapp.ts
@@ -1,0 +1,95 @@
+import "../env.js";
+import { Router } from "express";
+import { ulid } from "ulid";
+import { RunsRepository } from "../services/db.js";
+import { getBlobSasUrl } from "../services/blob.js";
+import { pollStatus, triggerRun } from "../services/logicapp.js";
+import { RunRecord, RunStatus } from "../types.js";
+
+const inputPrefix = process.env.INPUT_PREFIX ?? "input/";
+const outputPrefix = process.env.OUTPUT_PREFIX ?? "output/";
+const sasExpiry = parseInt(process.env.BLOB_SAS_EXPIRY_MINUTES ?? "30", 10);
+
+export function createLogicAppRouter(repo: RunsRepository) {
+  const router = Router();
+
+  router.post("/trigger", async (req, res) => {
+    try {
+      const { fileName, parameters } = req.body ?? {};
+      if (!fileName || typeof fileName !== "string") {
+        return res
+          .status(400)
+          .json({ ok: false, message: "fileName is required" });
+      }
+
+      if (!fileName.startsWith(inputPrefix)) {
+        return res.status(400).json({
+          ok: false,
+          message: `fileName must start with ${inputPrefix}`,
+        });
+      }
+
+      const sasUrl = getBlobSasUrl(fileName, "r", sasExpiry);
+
+      const triggerResult = await triggerRun({
+        sasUrl,
+        params: parameters && typeof parameters === "object" ? parameters : {},
+      });
+
+      const id = ulid();
+      const now = new Date().toISOString();
+      const status: RunStatus = triggerResult.location || triggerResult.trackingUrl
+        ? "Running"
+        : triggerResult.runId
+        ? "Queued"
+        : "Queued";
+
+      const run: RunRecord = {
+        id,
+        fileName,
+        fileUrl: sasUrl,
+        logicRunId: triggerResult.runId ?? null,
+        status,
+        createdAt: now,
+        updatedAt: now,
+        outputPrefix: `${outputPrefix}${id}/`,
+        trackingUrl: triggerResult.trackingUrl ?? null,
+        location: triggerResult.location ?? null,
+      };
+
+      repo.create(run);
+
+      return res.json({ run });
+    } catch (error: any) {
+      console.error("Trigger Logic App failed", error);
+      return res.status(500).json({
+        ok: false,
+        message: error?.message ?? "Failed to trigger Logic App",
+      });
+    }
+  });
+
+  router.post("/:id/poll", async (req, res) => {
+    try {
+      const id = req.params.id;
+      const run = repo.get(id);
+      if (!run) {
+        return res.status(404).json({ ok: false, message: "Run not found" });
+      }
+
+      const status = await pollStatus({
+        runId: run.logicRunId,
+        trackingUrl: run.trackingUrl,
+        location: run.location,
+      });
+
+      const updated = repo.updateStatus(id, status, {});
+      return res.json({ run: updated ?? run });
+    } catch (error) {
+      console.error("Poll run failed", error);
+      return res.status(500).json({ ok: false, message: "Failed to poll run" });
+    }
+  });
+
+  return router;
+}

--- a/apps/api/src/routes/output.ts
+++ b/apps/api/src/routes/output.ts
@@ -1,0 +1,79 @@
+import "../env.js";
+import { Router } from "express";
+import { getContainerClient, listBlobs, streamTextBlob } from "../services/blob.js";
+import { shouldPreview } from "../services/preview.js";
+
+const outputPrefix = process.env.OUTPUT_PREFIX ?? "output/";
+
+export function createOutputRouter() {
+  const router = Router();
+
+  router.get("/list", async (req, res) => {
+    try {
+      const prefix = (req.query.prefix as string) ?? outputPrefix;
+      const blobs = await listBlobs(prefix);
+      return res.json(blobs);
+    } catch (error) {
+      console.error("List output failed", error);
+      return res.status(500).json({ ok: false, message: "Failed to list output" });
+    }
+  });
+
+  router.get("/preview", async (req, res) => {
+    try {
+      const blobPath = req.query.blob as string;
+      if (!blobPath) {
+        return res.status(400).json({ ok: false, message: "blob query is required" });
+      }
+      const client = getContainerClient().getBlobClient(blobPath);
+      const props = await client.getProperties();
+      const contentType = props.contentType ?? "application/octet-stream";
+      const size = props.contentLength ?? 0;
+
+      if (!shouldPreview(contentType, size)) {
+        return res
+          .status(413)
+          .json({ ok: false, message: "too large to preview" });
+      }
+
+      let text: string;
+      try {
+        text = await streamTextBlob(blobPath, 5 * 1024 * 1024);
+      } catch (err: any) {
+        return res
+          .status(413)
+          .json({ ok: false, message: "too large to preview" });
+      }
+      res.setHeader("Content-Type", contentType);
+      return res.send(text);
+    } catch (error) {
+      console.error("Preview failed", error);
+      return res.status(500).json({ ok: false, message: "Failed to preview blob" });
+    }
+  });
+
+  router.get("/download", async (req, res) => {
+    try {
+      const blobPath = req.query.blob as string;
+      if (!blobPath) {
+        return res.status(400).json({ ok: false, message: "blob query is required" });
+      }
+      const client = getContainerClient().getBlobClient(blobPath);
+      const props = await client.getProperties();
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="${encodeURIComponent(blobPath.split("/").pop() || "download")}"`
+      );
+      if (props.contentType) {
+        res.setHeader("Content-Type", props.contentType);
+      }
+      const download = await client.download();
+      download.readableStreamBody?.pipe(res);
+    } catch (error) {
+      console.error("Download failed", error);
+      return res.status(500).json({ ok: false, message: "Failed to download blob" });
+    }
+  });
+
+  return router;
+}

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import { RunsRepository } from "../services/db.js";
+
+export function createRunsRouter(repo: RunsRepository) {
+  const router = Router();
+
+  router.get("/", (req, res) => {
+    const runs = repo.list(100);
+    return res.json(runs);
+  });
+
+  router.get("/:id", (req, res) => {
+    const run = repo.get(req.params.id);
+    if (!run) {
+      return res.status(404).json({ ok: false, message: "Run not found" });
+    }
+    return res.json(run);
+  });
+
+  return router;
+}

--- a/apps/api/src/services/blob.ts
+++ b/apps/api/src/services/blob.ts
@@ -1,0 +1,135 @@
+import "../env.js";
+import {
+  BlobServiceClient,
+  BlockBlobClient,
+  ContainerClient,
+  SASProtocol,
+  StorageSharedKeyCredential,
+  generateBlobSASQueryParameters,
+} from "@azure/storage-blob";
+import { Readable } from "stream";
+
+const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME;
+const accountKey = process.env.AZURE_STORAGE_ACCOUNT_KEY;
+const containerName = process.env.AZURE_STORAGE_CONTAINER;
+
+if (!accountName || !accountKey || !containerName) {
+  throw new Error(
+    "Missing storage configuration. Ensure account name, key, and container are set."
+  );
+}
+
+const sharedKeyCredential = new StorageSharedKeyCredential(
+  accountName,
+  accountKey
+);
+
+const blobServiceClient = new BlobServiceClient(
+  `https://${accountName}.blob.core.windows.net`,
+  sharedKeyCredential
+);
+
+const containerClient: ContainerClient = blobServiceClient.getContainerClient(
+  containerName
+);
+
+export function getContainerClient() {
+  return containerClient;
+}
+
+export function guessContentType(fileName: string): string {
+  const ext = fileName.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "json":
+      return "application/json";
+    case "csv":
+      return "text/csv";
+    case "txt":
+    case "log":
+      return "text/plain";
+    case "xml":
+      return "application/xml";
+    case "sql":
+      return "application/sql";
+    case "pdf":
+      return "application/pdf";
+    case "xlsx":
+      return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+export async function uploadBlob(
+  buffer: Buffer,
+  contentType: string,
+  blobPath: string
+) {
+  const client: BlockBlobClient = containerClient.getBlockBlobClient(blobPath);
+  await client.uploadData(buffer, {
+    blobHTTPHeaders: { blobContentType: contentType },
+  });
+}
+
+export async function listBlobs(prefix: string) {
+  const results: Array<{
+    name: string;
+    size: number;
+    lastModified: string;
+    contentType?: string;
+  }> = [];
+
+  for await (const item of containerClient.listBlobsFlat({ prefix })) {
+    results.push({
+      name: item.name,
+      size: item.properties.contentLength ?? 0,
+      lastModified: item.properties.lastModified?.toISOString() ?? "",
+      contentType: item.properties.contentType ?? undefined,
+    });
+  }
+
+  return results;
+}
+
+export function getBlobSasUrl(
+  blobPath: string,
+  permissions: string,
+  expiryMinutes: number
+) {
+  const expiresOn = new Date(Date.now() + expiryMinutes * 60 * 1000);
+  const sasToken = generateBlobSASQueryParameters(
+    {
+      containerName,
+      blobName: blobPath,
+      expiresOn,
+      permissions,
+      protocol: SASProtocol.Https,
+    },
+    sharedKeyCredential
+  ).toString();
+
+  return `https://${accountName}.blob.core.windows.net/${containerName}/${blobPath}?${sasToken}`;
+}
+
+export async function streamTextBlob(blobPath: string, maxBytes: number) {
+  const client = containerClient.getBlobClient(blobPath);
+  const download = await client.download();
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  const stream = download.readableStreamBody as Readable | null;
+  if (!stream) {
+    throw new Error("Unable to read blob stream");
+  }
+
+  for await (const chunk of stream) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > maxBytes) {
+      throw new Error("Blob too large for inline preview");
+    }
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks).toString("utf-8");
+}

--- a/apps/api/src/services/db.ts
+++ b/apps/api/src/services/db.ts
@@ -1,0 +1,77 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { RunRecord, RunStatus } from "../types.js";
+
+type RunsData = {
+  runs: RunRecord[];
+};
+
+export class RunsRepository {
+  private filePath: string;
+  private data: RunsData;
+
+  constructor(filePath: string) {
+    this.filePath = resolve(filePath);
+    this.ensureStore();
+    this.data = this.read();
+  }
+
+  private ensureStore() {
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    if (!existsSync(this.filePath)) {
+      const initial: RunsData = { runs: [] };
+      writeFileSync(this.filePath, JSON.stringify(initial, null, 2), "utf8");
+    }
+  }
+
+  private read(): RunsData {
+    try {
+      const raw = readFileSync(this.filePath, "utf8");
+      const parsed = JSON.parse(raw) as RunsData;
+      if (!parsed.runs) {
+        return { runs: [] };
+      }
+      return { runs: [...parsed.runs] };
+    } catch {
+      return { runs: [] };
+    }
+  }
+
+  private persist() {
+    writeFileSync(this.filePath, JSON.stringify(this.data, null, 2), "utf8");
+  }
+
+  public create(run: RunRecord) {
+    this.data.runs.push(run);
+    this.persist();
+    return run;
+  }
+
+  public list(limit = 100): RunRecord[] {
+    return [...this.data.runs]
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, limit);
+  }
+
+  public get(id: string): RunRecord | undefined {
+    return this.data.runs.find((run) => run.id === id);
+  }
+
+  public update(id: string, patch: Partial<Omit<RunRecord, "id">>) {
+    const index = this.data.runs.findIndex((run) => run.id === id);
+    if (index === -1) return undefined;
+    const existing = this.data.runs[index];
+    const updated: RunRecord = { ...existing, ...patch, id };
+    updated.updatedAt = new Date().toISOString();
+    this.data.runs[index] = updated;
+    this.persist();
+    return updated;
+  }
+
+  public updateStatus(id: string, status: RunStatus, extra: Partial<RunRecord> = {}) {
+    return this.update(id, { status, ...extra });
+  }
+}

--- a/apps/api/src/services/logicapp.ts
+++ b/apps/api/src/services/logicapp.ts
@@ -1,0 +1,137 @@
+import "../env.js";
+import axios from "axios";
+import { RunStatus } from "../types.js";
+
+const triggerUrl = process.env.LOGIC_APP_TRIGGER_URL;
+if (!triggerUrl) {
+  throw new Error("LOGIC_APP_TRIGGER_URL must be configured");
+}
+
+const bearer = process.env.LOGIC_APP_BEARER;
+
+interface TriggerOptions {
+  sasUrl: string;
+  params?: Record<string, unknown>;
+}
+
+export async function triggerRun({ sasUrl, params }: TriggerOptions) {
+  const payload = {
+    file: sasUrl,
+    config: "",
+    sourceMappingPrompt: "",
+    selectMappingPrompt: "",
+    ...params,
+  };
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (bearer) {
+    headers["Authorization"] = `Bearer ${bearer}`;
+  }
+
+  const response = await axios.post(triggerUrl, payload, {
+    validateStatus: () => true,
+    headers,
+  });
+
+  if (response.status >= 400) {
+    throw new Error(
+      `Logic App trigger failed: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const location = response.headers["location"] as string | undefined;
+  let runId: string | undefined;
+  let trackingUrl: string | undefined;
+
+  if (typeof response.data === "object" && response.data) {
+    const data = response.data as Record<string, unknown>;
+    if (typeof data["runId"] === "string") {
+      runId = data["runId"] as string;
+    }
+    if (typeof data["trackingUrl"] === "string") {
+      trackingUrl = data["trackingUrl"] as string;
+    }
+    if (!trackingUrl && typeof data["statusQueryGetUri"] === "string") {
+      trackingUrl = data["statusQueryGetUri"] as string;
+    }
+  }
+
+  return { runId, trackingUrl, location };
+}
+
+interface PollOptions {
+  runId?: string | null;
+  trackingUrl?: string | null;
+  location?: string | null;
+}
+
+export async function pollStatus({
+  runId,
+  trackingUrl,
+  location,
+}: PollOptions): Promise<RunStatus | "Unknown"> {
+  const url = trackingUrl || location;
+  if (!url) {
+    return "Unknown";
+  }
+
+  const headers: Record<string, string> = {};
+  if (bearer) {
+    headers["Authorization"] = `Bearer ${bearer}`;
+  }
+
+  const response = await axios.get(url, {
+    validateStatus: () => true,
+    headers,
+  });
+
+  if (response.status === 202) {
+    return "Running";
+  }
+
+  if (response.status >= 400) {
+    return "Failed";
+  }
+
+  const data = response.data;
+  if (data && typeof data === "object") {
+    const status = normalizeStatus((data as Record<string, unknown>)["status"]);
+    if (status !== "Unknown") {
+      return status;
+    }
+  }
+
+  if (runId && typeof response.headers["x-ms-status"] === "string") {
+    const status = normalizeStatus(response.headers["x-ms-status"]);
+    if (status !== "Unknown") {
+      return status;
+    }
+  }
+
+  return "Unknown";
+}
+
+function normalizeStatus(value: unknown): RunStatus | "Unknown" {
+  if (typeof value !== "string") return "Unknown";
+  const normalized = value.toLowerCase();
+  switch (normalized) {
+    case "queued":
+      return "Queued";
+    case "running":
+    case "inprogress":
+      return "Running";
+    case "succeeded":
+    case "success":
+      return "Succeeded";
+    case "failed":
+    case "failure":
+      return "Failed";
+    case "cancelled":
+    case "canceled":
+      return "Canceled";
+    default:
+      return "Unknown";
+  }
+}

--- a/apps/api/src/services/preview.ts
+++ b/apps/api/src/services/preview.ts
@@ -1,0 +1,14 @@
+const TEXT_TYPES = new Set([
+  "text/plain",
+  "text/csv",
+  "application/json",
+  "application/sql",
+  "application/xml",
+]);
+
+export function shouldPreview(contentType: string | undefined, size: number) {
+  if (!contentType) return false;
+  if (size > 5 * 1024 * 1024) return false; // 5 MB
+  if (contentType.startsWith("text/")) return true;
+  return TEXT_TYPES.has(contentType);
+}

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,0 +1,29 @@
+export type RunStatus =
+  | "Queued"
+  | "Running"
+  | "Succeeded"
+  | "Failed"
+  | "Canceled"
+  | "Unknown";
+
+export interface RunRecord {
+  id: string;
+  fileName: string;
+  fileUrl: string;
+  logicRunId: string | null;
+  status: RunStatus;
+  createdAt: string;
+  updatedAt: string;
+  outputPrefix: string;
+  trackingUrl?: string | null;
+  location?: string | null;
+}
+
+export interface TriggerRunRequest {
+  fileName: string;
+  parameters?: Record<string, unknown>;
+}
+
+export interface TriggerRunResponse {
+  run: RunRecord;
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/web/css/style.css
+++ b/apps/web/css/style.css
@@ -1,0 +1,20 @@
+body {
+  background-color: #f5f6f8;
+}
+
+.card {
+  border: none;
+}
+
+#alertContainer .alert {
+  margin-bottom: 1rem;
+}
+
+#previewPane {
+  white-space: pre-wrap;
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  min-height: 200px;
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Logic App Trigger</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <div class="container">
+        <a class="navbar-brand" href="index.html">Logic App Runner</a>
+        <div class="navbar-nav">
+          <a class="nav-link" href="status.html">Runs</a>
+          <a class="nav-link" href="output.html">Output</a>
+        </div>
+      </div>
+    </nav>
+    <main class="container py-4">
+      <div id="alertContainer"></div>
+      <section class="mb-4">
+        <div class="card shadow-sm">
+          <div class="card-body">
+            <h2 class="h5">Upload file</h2>
+            <div class="row g-3 align-items-end">
+              <div class="col-md-6">
+                <label for="fileInput" class="form-label">Choose file</label>
+                <input class="form-control" type="file" id="fileInput" />
+              </div>
+              <div class="col-md-3">
+                <button class="btn btn-primary w-100" id="uploadBtn">Upload</button>
+              </div>
+            </div>
+            <div class="form-text mt-2">Max size: 200 MB.</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="mb-4">
+        <div class="card shadow-sm">
+          <div class="card-body">
+            <h2 class="h5">Trigger Logic App</h2>
+            <div class="mb-3">
+              <label for="fileSelect" class="form-label">Available input files</label>
+              <div class="d-flex gap-2">
+                <select class="form-select" id="fileSelect"></select>
+                <button class="btn btn-outline-secondary" id="refreshBtn">Refresh</button>
+              </div>
+            </div>
+            <div class="row g-3">
+              <div class="col-md-4">
+                <label for="targetType" class="form-label">Target type</label>
+                <select class="form-select" id="targetType">
+                  <option value="Postgres">Postgres</option>
+                  <option value="SQLServer">SQL Server</option>
+                  <option value="BigQuery">BigQuery</option>
+                </select>
+              </div>
+              <div class="col-md-4">
+                <label for="targetEnv" class="form-label">Target environment</label>
+                <select class="form-select" id="targetEnv">
+                  <option value="DEV">DEV</option>
+                  <option value="UAT">UAT</option>
+                  <option value="PROD">PROD</option>
+                </select>
+              </div>
+              <div class="col-md-4">
+                <label for="extraParams" class="form-label">Extra parameters (JSON)</label>
+                <textarea class="form-control" id="extraParams" rows="3" placeholder='{"k":"v"}'></textarea>
+              </div>
+            </div>
+            <div class="mt-3">
+              <button class="btn btn-success" id="triggerBtn">Trigger Logic App</button>
+            </div>
+            <div class="mt-3" id="triggerResult"></div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="js/main.js" type="module"></script>
+  </body>
+</html>

--- a/apps/web/js/config.js
+++ b/apps/web/js/config.js
@@ -1,0 +1,87 @@
+const GLOBAL_BASE_KEYS = [
+  "API_BASE_URL",
+  "__API_BASE__",
+  "VITE_API_BASE_URL",
+];
+
+function sanitizeBase(base) {
+  return base.replace(/\/+$/, "");
+}
+
+function resolveFromWindow() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  for (const key of GLOBAL_BASE_KEYS) {
+    const value = window[key];
+    if (typeof value === "string" && value.trim()) {
+      return sanitizeBase(value.trim());
+    }
+  }
+
+  const origin = window.location && window.location.origin;
+  if (origin && origin !== "null" && !origin.startsWith("file:")) {
+    const port = window.location && window.location.port;
+    if (!port || port === "4100") {
+      return sanitizeBase(origin) + "/api";
+    }
+  }
+
+  return null;
+}
+
+function resolveApiBase() {
+  const fromWindow = resolveFromWindow();
+  if (fromWindow) {
+    return fromWindow;
+  }
+  return "http://localhost:4100/api";
+}
+
+export const API_BASE = resolveApiBase();
+
+export function buildApiUrl(path) {
+  if (!path.startsWith("/")) {
+    path = `/${path}`;
+  }
+  return `${API_BASE}${path}`;
+}
+
+export async function checkApiHealth(timeoutMs = 5000) {
+  const url = buildApiUrl("/health");
+  const supportsAbort = typeof AbortController !== "undefined";
+  const controller = supportsAbort ? new AbortController() : null;
+  const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+  try {
+    const res = await fetch(url, controller ? { signal: controller.signal } : undefined);
+    if (timer) {
+      clearTimeout(timer);
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      let message = `API at ${url} responded with status ${res.status}.`;
+      const trimmed = text.trim();
+      if (trimmed) {
+        if (trimmed.startsWith("<")) {
+          message += " Received HTML; check that the API base URL is correct.";
+        } else {
+          message += ` ${trimmed}`;
+        }
+      }
+      return { ok: false, message };
+    }
+
+    return { ok: true };
+  } catch (error) {
+    let message = `Unable to reach API at ${url}.`;
+    if (error && typeof error === "object") {
+      if (error.name === "AbortError") {
+        message += " Request timed out.";
+      } else if (typeof error.message === "string" && error.message) {
+        message += ` ${error.message}`;
+      }
+    }
+    return { ok: false, message };
+  }
+}

--- a/apps/web/js/main.js
+++ b/apps/web/js/main.js
@@ -1,0 +1,180 @@
+import { API_BASE, buildApiUrl, checkApiHealth } from "./config.js";
+
+const fileInput = document.getElementById("fileInput");
+const uploadBtn = document.getElementById("uploadBtn");
+const fileSelect = document.getElementById("fileSelect");
+const refreshBtn = document.getElementById("refreshBtn");
+const targetType = document.getElementById("targetType");
+const targetEnv = document.getElementById("targetEnv");
+const extraParams = document.getElementById("extraParams");
+const triggerBtn = document.getElementById("triggerBtn");
+const triggerResult = document.getElementById("triggerResult");
+const alertContainer = document.getElementById("alertContainer");
+
+function showAlert(message, type = "danger") {
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = `
+    <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+      ${message}
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+  `;
+  alertContainer.appendChild(wrapper);
+}
+
+async function parseJsonResponse(res, defaultMessage) {
+  const text = await res.text();
+  if (!res.ok) {
+    let message = defaultMessage ?? `Request failed with status ${res.status}`;
+    if (text) {
+      try {
+        const data = JSON.parse(text);
+        if (typeof data.message === "string") {
+          message = data.message;
+        } else if (typeof data.error === "string") {
+          message = data.error;
+        }
+      } catch {
+        const trimmed = text.trim();
+        if (trimmed && !trimmed.startsWith("<")) {
+          message = trimmed;
+        }
+      }
+    }
+    throw new Error(message);
+  }
+
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    const trimmed = text.trim();
+    if (trimmed.startsWith("<")) {
+      throw new Error(
+        "Server returned HTML instead of JSON. Ensure the API base URL is correct and the backend is running."
+      );
+    }
+    throw new Error(defaultMessage ?? "Received malformed JSON from server.");
+  }
+}
+
+async function fetchInputFiles() {
+  try {
+    fileSelect.innerHTML = `<option>Loading...</option>`;
+    const res = await fetch(buildApiUrl("/files/list?prefix=input/"));
+    const files = (await parseJsonResponse(res, "Failed to load files")) ?? [];
+    if (!Array.isArray(files) || files.length === 0) {
+      fileSelect.innerHTML = `<option value="">No files available</option>`;
+      return;
+    }
+    fileSelect.innerHTML = "";
+    for (const file of files) {
+      const option = document.createElement("option");
+      option.value = file.name;
+      option.textContent = `${file.name} (${(file.size / 1024).toFixed(1)} KB)`;
+      fileSelect.appendChild(option);
+    }
+  } catch (error) {
+    showAlert(error.message);
+  }
+}
+
+uploadBtn?.addEventListener("click", async () => {
+  if (!fileInput.files?.length) {
+    showAlert("Select a file to upload", "warning");
+    return;
+  }
+  const file = fileInput.files[0];
+  const formData = new FormData();
+  formData.append("file", file);
+
+  uploadBtn.disabled = true;
+  uploadBtn.innerText = "Uploading...";
+
+  try {
+    const res = await fetch(buildApiUrl("/files/upload"), {
+      method: "POST",
+      body: formData,
+    });
+    const data = (await parseJsonResponse(res, "Upload failed")) ?? {
+      fileName: "",
+    };
+    showAlert(`Uploaded ${data.fileName}`, "success");
+    fileInput.value = "";
+    await fetchInputFiles();
+  } catch (error) {
+    showAlert(error.message || "Upload failed");
+  } finally {
+    uploadBtn.disabled = false;
+    uploadBtn.innerText = "Upload";
+  }
+});
+
+refreshBtn?.addEventListener("click", fetchInputFiles);
+
+triggerBtn?.addEventListener("click", async () => {
+  const fileName = fileSelect.value;
+  if (!fileName) {
+    showAlert("Choose a file before triggering", "warning");
+    return;
+  }
+
+  let params = {
+    target_type: targetType.value,
+    target_env: targetEnv.value,
+  };
+
+  const extra = extraParams.value.trim();
+  if (extra) {
+    try {
+      const parsed = JSON.parse(extra);
+      params = { ...params, ...parsed };
+    } catch (error) {
+      showAlert("Extra parameters must be valid JSON", "warning");
+      return;
+    }
+  }
+
+  triggerBtn.disabled = true;
+  triggerBtn.innerText = "Triggering...";
+  triggerResult.innerHTML = "";
+
+  try {
+    const res = await fetch(buildApiUrl("/logicapp/trigger"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fileName, parameters: params }),
+    });
+    const data = await parseJsonResponse(res, "Trigger failed");
+    if (!data || typeof data !== "object" || !("run" in data)) {
+      throw new Error("Unexpected response from trigger endpoint");
+    }
+    const run = data.run;
+    triggerResult.innerHTML = `
+      <div class="alert alert-info">
+        Run <strong>${run.id}</strong> created with status <span class="badge bg-primary">${run.status}</span>.
+        <a class="ms-2" href="status.html">View Status</a>
+      </div>
+    `;
+  } catch (error) {
+    showAlert(error.message || "Trigger failed");
+  } finally {
+    triggerBtn.disabled = false;
+    triggerBtn.innerText = "Trigger Logic App";
+  }
+});
+
+async function init() {
+  const health = await checkApiHealth();
+  if (!health.ok) {
+    showAlert(health.message ?? `Unable to reach API at ${API_BASE}`);
+    return;
+  }
+  await fetchInputFiles();
+}
+
+init();
+

--- a/apps/web/js/output.js
+++ b/apps/web/js/output.js
@@ -1,0 +1,221 @@
+import { API_BASE, buildApiUrl, checkApiHealth } from "./config.js";
+const prefixInput = document.getElementById("prefixInput");
+const listBtn = document.getElementById("listBtn");
+const fileList = document.getElementById("fileList");
+const previewPane = document.getElementById("previewPane");
+const outputAlert = document.getElementById("outputAlert");
+
+async function parseJsonResponse(res, defaultMessage) {
+  const text = await res.text();
+  if (!res.ok) {
+    let message = defaultMessage ?? `Request failed with status ${res.status}`;
+    if (text) {
+      try {
+        const data = JSON.parse(text);
+        if (typeof data.message === "string") {
+          message = data.message;
+        } else if (typeof data.error === "string") {
+          message = data.error;
+        }
+      } catch {
+        const trimmed = text.trim();
+        if (trimmed && !trimmed.startsWith("<")) {
+          message = trimmed;
+        }
+      }
+    }
+    throw new Error(message);
+  }
+
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    const trimmed = text.trim();
+    if (trimmed.startsWith("<")) {
+      throw new Error(
+        "Server returned HTML instead of JSON. Ensure the API base URL is correct and the backend is running."
+      );
+    }
+    throw new Error(defaultMessage ?? "Received malformed JSON from server.");
+  }
+}
+
+function showOutputAlert(message, type = "danger") {
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = `
+    <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+      ${message}
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+  `;
+  outputAlert.appendChild(wrapper);
+}
+
+function getInitialPrefix() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("prefix") || "output/";
+}
+
+async function listOutputs() {
+  const prefix = prefixInput.value || "output/";
+  fileList.innerHTML = `<div class="list-group-item">Loading...</div>`;
+  try {
+    const res = await fetch(buildApiUrl(`/output/list?prefix=${encodeURIComponent(prefix)}`));
+    const blobs = (await parseJsonResponse(res, "Failed to load output files")) ?? [];
+    renderFileList(blobs);
+  } catch (error) {
+    showOutputAlert(error.message);
+    fileList.innerHTML = "";
+  }
+}
+
+function renderFileList(blobs) {
+  fileList.innerHTML = "";
+  if (!Array.isArray(blobs) || blobs.length === 0) {
+    fileList.innerHTML = `<div class="list-group-item text-muted">No files found</div>`;
+    return;
+  }
+
+  for (const blob of blobs) {
+    const item = document.createElement("div");
+    item.className = "list-group-item d-flex justify-content-between align-items-center flex-wrap";
+    item.innerHTML = `
+      <div class="me-2">
+        <div>${blob.name}</div>
+        <small class="text-muted">${(blob.size / 1024).toFixed(1)} KB · ${blob.lastModified ? new Date(blob.lastModified).toLocaleString() : ""}</small>
+      </div>
+      <div class="btn-group btn-group-sm" role="group">
+        <button class="btn btn-outline-primary" data-action="preview" data-blob="${encodeURIComponent(blob.name)}">Preview</button>
+        <a class="btn btn-outline-secondary" href="${buildApiUrl(`/output/download?blob=${encodeURIComponent(blob.name)}`)}">Download</a>
+      </div>
+    `;
+    fileList.appendChild(item);
+  }
+}
+
+fileList.addEventListener("click", async (event) => {
+  const btn = event.target.closest("button[data-action='preview']");
+  if (!btn) return;
+  const blob = decodeURIComponent(btn.dataset.blob);
+  await previewBlob(blob);
+});
+
+async function previewBlob(blob) {
+  previewPane.textContent = "Loading preview...";
+  try {
+    const res = await fetch(buildApiUrl(`/output/preview?blob=${encodeURIComponent(blob)}`));
+    if (res.status === 413) {
+      const err = await res.json().catch(() => ({ message: "Too large to preview" }));
+      previewPane.innerHTML = `
+        <div class="alert alert-warning">${err.message || "Too large to preview"}</div>
+        <a class="btn btn-sm btn-outline-secondary" href="${buildApiUrl(`/output/download?blob=${encodeURIComponent(blob)}`)}">Download instead</a>
+      `;
+      return;
+    }
+    if (!res.ok) throw new Error("Failed to preview file");
+    const contentType = res.headers.get("Content-Type") || "";
+    const text = await res.text();
+    renderPreview(text, contentType);
+  } catch (error) {
+    previewPane.innerHTML = `<div class="alert alert-danger">${error.message}</div>`;
+  }
+}
+
+function renderPreview(text, contentType) {
+  if (contentType.includes("application/json")) {
+    try {
+      const parsed = JSON.parse(text);
+      previewPane.textContent = JSON.stringify(parsed, null, 2);
+      return;
+    } catch (error) {
+      // fall back to raw text
+    }
+  }
+
+  if (contentType.includes("text/csv")) {
+    previewPane.innerHTML = csvToTable(text);
+    return;
+  }
+
+  previewPane.textContent = text;
+}
+
+function csvToTable(csvText) {
+  const rows = csvText.split(/\r?\n/).slice(0, 2000).filter((row) => row.length > 0);
+  if (rows.length === 0) {
+    return `<div class="text-muted">Empty file</div>`;
+  }
+  const table = document.createElement("table");
+  table.className = "table table-striped table-bordered table-sm";
+  const thead = document.createElement("thead");
+  const headerCells = parseCsvLine(rows[0]);
+  const headerRow = document.createElement("tr");
+  for (const cell of headerCells) {
+    const th = document.createElement("th");
+    th.textContent = cell;
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+  for (const row of rows.slice(1)) {
+    const tr = document.createElement("tr");
+    const cells = parseCsvLine(row);
+    for (const cell of cells) {
+      const td = document.createElement("td");
+      td.textContent = cell;
+      tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  const wrapper = document.createElement("div");
+  wrapper.appendChild(table);
+  return wrapper.innerHTML;
+}
+
+function parseCsvLine(line) {
+  const result = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === "," && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+const initialPrefix = getInitialPrefix();
+prefixInput.value = initialPrefix;
+listBtn.addEventListener("click", listOutputs);
+
+async function init() {
+  const health = await checkApiHealth();
+  if (!health.ok) {
+    showOutputAlert(health.message ?? `Unable to reach API at ${API_BASE}`);
+    fileList.innerHTML = "";
+    return;
+  }
+  await listOutputs();
+}
+
+init();
+

--- a/apps/web/js/status.js
+++ b/apps/web/js/status.js
@@ -1,0 +1,151 @@
+import { API_BASE, buildApiUrl, checkApiHealth } from "./config.js";
+const runsTableBody = document.querySelector("#runsTable tbody");
+const statusAlert = document.getElementById("statusAlert");
+const runJson = document.getElementById("runJson");
+const runModalEl = document.getElementById("runModal");
+const modal = runModalEl ? new bootstrap.Modal(runModalEl) : null;
+
+async function parseJsonResponse(res, defaultMessage) {
+  const text = await res.text();
+  if (!res.ok) {
+    let message = defaultMessage ?? `Request failed with status ${res.status}`;
+    if (text) {
+      try {
+        const data = JSON.parse(text);
+        if (typeof data.message === "string") {
+          message = data.message;
+        } else if (typeof data.error === "string") {
+          message = data.error;
+        }
+      } catch {
+        const trimmed = text.trim();
+        if (trimmed && !trimmed.startsWith("<")) {
+          message = trimmed;
+        }
+      }
+    }
+    throw new Error(message);
+  }
+
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    const trimmed = text.trim();
+    if (trimmed.startsWith("<")) {
+      throw new Error(
+        "Server returned HTML instead of JSON. Ensure the API base URL is correct and the backend is running."
+      );
+    }
+    throw new Error(defaultMessage ?? "Received malformed JSON from server.");
+  }
+}
+
+function showStatusAlert(message, type = "danger") {
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = `
+    <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+      ${message}
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+  `;
+  statusAlert.appendChild(wrapper);
+}
+
+function statusBadge(status) {
+  const map = {
+    Queued: "secondary",
+    Running: "primary",
+    Succeeded: "success",
+    Failed: "danger",
+    Canceled: "warning",
+    Unknown: "dark",
+  };
+  const variant = map[status] || "secondary";
+  return `<span class="badge bg-${variant}">${status}</span>`;
+}
+
+function formatDate(dateString) {
+  if (!dateString) return "";
+  return new Date(dateString).toLocaleString();
+}
+
+async function fetchRuns() {
+  try {
+    const res = await fetch(buildApiUrl("/runs"));
+    const runs = (await parseJsonResponse(res, "Failed to load runs")) ?? [];
+    renderRuns(runs);
+  } catch (error) {
+    showStatusAlert(error.message);
+  }
+}
+
+function renderRuns(runs) {
+  runsTableBody.innerHTML = "";
+  if (!Array.isArray(runs) || runs.length === 0) {
+    runsTableBody.innerHTML = `
+      <tr><td colspan="6" class="text-center py-4 text-muted">No runs yet</td></tr>
+    `;
+    return;
+  }
+  for (const run of runs) {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${run.fileName}</td>
+      <td><code>${run.id}</code></td>
+      <td>${statusBadge(run.status)}</td>
+      <td>${formatDate(run.createdAt)}</td>
+      <td>${formatDate(run.updatedAt)}</td>
+      <td>
+        <div class="btn-group btn-group-sm" role="group">
+          <button class="btn btn-outline-primary poll-btn" data-id="${run.id}">Poll</button>
+          ${run.status === "Succeeded" ? `<a class="btn btn-outline-success" href="output.html?prefix=${encodeURIComponent(run.outputPrefix)}">Output</a>` : ""}
+        </div>
+      </td>
+    `;
+    tr.dataset.run = JSON.stringify(run);
+    tr.addEventListener("click", (event) => {
+      if (event.target.closest("button") || event.target.closest("a")) {
+        return;
+      }
+      if (modal) {
+        runJson.textContent = JSON.stringify(JSON.parse(tr.dataset.run), null, 2);
+        modal.show();
+      }
+    });
+    runsTableBody.appendChild(tr);
+  }
+}
+
+runsTableBody.addEventListener("click", async (event) => {
+  const button = event.target.closest(".poll-btn");
+  if (!button) return;
+  const id = button.dataset.id;
+  button.disabled = true;
+  button.innerText = "Polling...";
+  try {
+    const res = await fetch(buildApiUrl(`/logicapp/${id}/poll`), { method: "POST" });
+    await parseJsonResponse(res, "Failed to poll");
+    await fetchRuns();
+  } catch (error) {
+    showStatusAlert(error.message || "Failed to poll");
+  } finally {
+    button.disabled = false;
+    button.innerText = "Poll";
+  }
+});
+
+async function init() {
+  const health = await checkApiHealth();
+  if (!health.ok) {
+    showStatusAlert(health.message ?? `Unable to reach API at ${API_BASE}`);
+    return;
+  }
+  await fetchRuns();
+}
+
+init();
+

--- a/apps/web/output.html
+++ b/apps/web/output.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Output Browser</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <div class="container">
+        <a class="navbar-brand" href="index.html">Logic App Runner</a>
+        <div class="navbar-nav">
+          <a class="nav-link" href="status.html">Runs</a>
+          <a class="nav-link active" aria-current="page" href="output.html">Output</a>
+        </div>
+      </div>
+    </nav>
+    <main class="container py-4">
+      <h1 class="h4 mb-3">Output browser</h1>
+      <div id="outputAlert"></div>
+      <div class="card shadow-sm mb-3">
+        <div class="card-body">
+          <div class="row g-3 align-items-end">
+            <div class="col-md-6">
+              <label for="prefixInput" class="form-label">Prefix</label>
+              <input type="text" class="form-control" id="prefixInput" placeholder="output/" />
+            </div>
+            <div class="col-md-2">
+              <button class="btn btn-primary w-100" id="listBtn">List</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row g-4">
+        <div class="col-lg-5">
+          <div class="card shadow-sm">
+            <div class="card-body">
+              <h2 class="h6">Files</h2>
+              <div class="list-group" id="fileList"></div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-7">
+          <div class="card shadow-sm">
+            <div class="card-body">
+              <h2 class="h6">Preview</h2>
+              <div id="previewPane" class="overflow-auto"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="js/output.js" type="module"></script>
+  </body>
+</html>

--- a/apps/web/status.html
+++ b/apps/web/status.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Run Status</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <div class="container">
+        <a class="navbar-brand" href="index.html">Logic App Runner</a>
+        <div class="navbar-nav">
+          <a class="nav-link active" aria-current="page" href="status.html">Runs</a>
+          <a class="nav-link" href="output.html">Output</a>
+        </div>
+      </div>
+    </nav>
+    <main class="container py-4">
+      <h1 class="h4 mb-3">Recent runs</h1>
+      <div id="statusAlert"></div>
+      <div class="table-responsive shadow-sm bg-white rounded">
+        <table class="table table-hover align-middle" id="runsTable">
+          <thead class="table-light">
+            <tr>
+              <th scope="col">File</th>
+              <th scope="col">Run ID</th>
+              <th scope="col">Status</th>
+              <th scope="col">Created</th>
+              <th scope="col">Updated</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </main>
+
+    <div class="modal fade" id="runModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Run details</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <pre class="mb-0" id="runJson"></pre>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="js/status.js" type="module"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "logicapp-blob-ui",
+  "private": true,
+  "workspaces": ["apps/*"],
+  "scripts": {
+    "dev": "pnpm --filter @app/api dev",
+    "build": "pnpm -r build",
+    "start": "pnpm --filter @app/api start"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - apps/*


### PR DESCRIPTION
## Summary
- stop the frontend config helper from reusing non-API ports such as 5173 so it falls back to http://localhost:4100/api unless explicitly overridden
- document the default behaviour in the README, including how to override the API base for other hosts

## Testing
- Tests not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4d1c824f483209f05a654a0cceb62